### PR TITLE
Add VNET peering between environments

### DIFF
--- a/avddeploy.bicep
+++ b/avddeploy.bicep
@@ -3,6 +3,7 @@ param vnetIPSpace string = '10.0.12.0/22'
 param avdUsersSubnetIP string = '10.0.12.0/24'
 param avdAdminsSubnetIP string = '10.0.13.0/24'
 param BastionsubnetIP string = '10.0.14.0/26'
+param servicesVnetId string
 
 param resourceTags object = {
   Environment: 'AVD'
@@ -97,4 +98,21 @@ resource loganalyticsname_resource 'Microsoft.OperationalInsights/workspaces@202
       name: 'pergb2018'
     }
   }
+}
+
+resource avdToServicesPeering 'Microsoft.Network/virtualNetworks/virtualNetworkPeerings@2020-05-01' = {
+  name: 'avdToServicesPeering'
+  location: location
+  properties: {
+    remoteVirtualNetwork: {
+      id: servicesVnetId
+    }
+    allowVirtualNetworkAccess: true
+    allowForwardedTraffic: true
+    allowGatewayTransit: false
+    useRemoteGateways: false
+  }
+  dependsOn: [
+    vnet
+  ]
 }

--- a/avddeploy.json
+++ b/avddeploy.json
@@ -31,6 +31,9 @@
         "Environment": "AVD",
         "Created_By": "IaC Deployment"
       }
+    },
+    "servicesVnetId": {
+      "type": "string"
     }
   },
   "variables": {
@@ -133,6 +136,24 @@
           "name": "pergb2018"
         }
       }
+    },
+    {
+      "type": "Microsoft.Network/virtualNetworks/virtualNetworkPeerings",
+      "apiVersion": "2020-05-01",
+      "name": "avdToServicesPeering",
+      "location": "[variables('location')]",
+      "properties": {
+        "remoteVirtualNetwork": {
+          "id": "[parameters('servicesVnetId')]"
+        },
+        "allowVirtualNetworkAccess": true,
+        "allowForwardedTraffic": true,
+        "allowGatewayTransit": false,
+        "useRemoteGateways": false
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Network/virtualNetworks', variables('avdVnet'))]"
+      ]
     }
   ]
 }

--- a/devdeploy.bicep
+++ b/devdeploy.bicep
@@ -4,6 +4,7 @@ param appSubnetIP string = '10.0.8.0/24'
 param dbSubnetIP string = '10.0.9.0/24'
 param webSubnetIP string = '10.0.10.0/24'
 param BastionsubnetIP string = '10.0.11.0/26'
+param servicesVnetId string
 
 param resourceTags object = {
   Environment: 'Dev/Test'
@@ -121,3 +122,19 @@ resource RecoveryServicesVault 'Microsoft.RecoveryServices/vaults@2023-01-01' = 
   }
 }
 
+resource devToServicesPeering 'Microsoft.Network/virtualNetworks/virtualNetworkPeerings@2020-05-01' = {
+  name: 'devToServicesPeering'
+  location: location
+  properties: {
+    remoteVirtualNetwork: {
+      id: servicesVnetId
+    }
+    allowVirtualNetworkAccess: true
+    allowForwardedTraffic: true
+    allowGatewayTransit: false
+    useRemoteGateways: false
+  }
+  dependsOn: [
+    vnet
+  ]
+}

--- a/devdeploy.json
+++ b/devdeploy.json
@@ -35,6 +35,9 @@
         "Environment": "Dev/Test",
         "Created_By": "IaC Deployment"
       }
+    },
+    "servicesVnetId": {
+      "type": "string"
     }
   },
   "variables": {
@@ -159,6 +162,24 @@
       "properties": {
         "publicNetworkAccess": "Enabled"
       }
+    },
+    {
+      "type": "Microsoft.Network/virtualNetworks/virtualNetworkPeerings",
+      "apiVersion": "2020-05-01",
+      "name": "devToServicesPeering",
+      "location": "[variables('location')]",
+      "properties": {
+        "remoteVirtualNetwork": {
+          "id": "[parameters('servicesVnetId')]"
+        },
+        "allowVirtualNetworkAccess": true,
+        "allowForwardedTraffic": true,
+        "allowGatewayTransit": false,
+        "useRemoteGateways": false
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Network/virtualNetworks', variables('devVnet'))]"
+      ]
     }
   ]
 }

--- a/proddeploy.bicep
+++ b/proddeploy.bicep
@@ -4,6 +4,7 @@ param appSubnetIP string = '10.0.4.0/24'
 param dbSubnetIP string = '10.0.5.0/24'
 param webSubnetIP string = '10.0.6.0/24'
 param BastionsubnetIP string = '10.0.7.0/26'
+param servicesVnetId string
 
 param resourceTags object = {
   Environment: 'Production'
@@ -121,3 +122,19 @@ resource RecoveryServicesVault 'Microsoft.RecoveryServices/vaults@2023-01-01' = 
   }
 }
 
+resource prodToServicesPeering 'Microsoft.Network/virtualNetworks/virtualNetworkPeerings@2020-05-01' = {
+  name: 'prodToServicesPeering'
+  location: location
+  properties: {
+    remoteVirtualNetwork: {
+      id: servicesVnetId
+    }
+    allowVirtualNetworkAccess: true
+    allowForwardedTraffic: true
+    allowGatewayTransit: false
+    useRemoteGateways: false
+  }
+  dependsOn: [
+    vnet
+  ]
+}

--- a/proddeploy.json
+++ b/proddeploy.json
@@ -35,6 +35,9 @@
         "Environment": "Production",
         "Created_By": "IaC Deployment"
       }
+    },
+    "servicesVnetId": {
+      "type": "string"
     }
   },
   "variables": {
@@ -159,6 +162,24 @@
       "properties": {
         "publicNetworkAccess": "Enabled"
       }
+    },
+    {
+      "type": "Microsoft.Network/virtualNetworks/virtualNetworkPeerings",
+      "apiVersion": "2020-05-01",
+      "name": "prodToServicesPeering",
+      "location": "[variables('location')]",
+      "properties": {
+        "remoteVirtualNetwork": {
+          "id": "[parameters('servicesVnetId')]"
+        },
+        "allowVirtualNetworkAccess": true,
+        "allowForwardedTraffic": true,
+        "allowGatewayTransit": false,
+        "useRemoteGateways": false
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Network/virtualNetworks', variables('prodVnet'))]"
+      ]
     }
   ]
 }

--- a/servicesdeploy.bicep
+++ b/servicesdeploy.bicep
@@ -15,6 +15,10 @@ param resourceTags object = {
   Created_By: 'IaC Deployment'
 }
 
+param avdVnetId string
+param devVnetId string
+param prodVnetId string
+
 var location = resourceGroup().location
 var servicesVnet = 'vnet_services_${location}'
 var servicesNSG = 'NSG_services_${location}'
@@ -129,5 +133,56 @@ resource Gateway 'Microsoft.Network/virtualNetworkGateways@2018-10-01' = {
   dependsOn: [
     vnet
 
+  ]
+}
+
+resource servicesToAvdPeering 'Microsoft.Network/virtualNetworks/virtualNetworkPeerings@2020-05-01' = {
+  name: 'servicesToAvdPeering'
+  location: location
+  properties: {
+    remoteVirtualNetwork: {
+      id: avdVnetId
+    }
+    allowVirtualNetworkAccess: true
+    allowForwardedTraffic: true
+    allowGatewayTransit: false
+    useRemoteGateways: false
+  }
+  dependsOn: [
+    vnet
+  ]
+}
+
+resource servicesToDevPeering 'Microsoft.Network/virtualNetworks/virtualNetworkPeerings@2020-05-01' = {
+  name: 'servicesToDevPeering'
+  location: location
+  properties: {
+    remoteVirtualNetwork: {
+      id: devVnetId
+    }
+    allowVirtualNetworkAccess: true
+    allowForwardedTraffic: true
+    allowGatewayTransit: false
+    useRemoteGateways: false
+  }
+  dependsOn: [
+    vnet
+  ]
+}
+
+resource servicesToProdPeering 'Microsoft.Network/virtualNetworks/virtualNetworkPeerings@2020-05-01' = {
+  name: 'servicesToProdPeering'
+  location: location
+  properties: {
+    remoteVirtualNetwork: {
+      id: prodVnetId
+    }
+    allowVirtualNetworkAccess: true
+    allowForwardedTraffic: true
+    allowGatewayTransit: false
+    useRemoteGateways: false
+  }
+  dependsOn: [
+    vnet
   ]
 }

--- a/servicesdeploy.json
+++ b/servicesdeploy.json
@@ -43,6 +43,15 @@
         "Environment": "Services",
         "Created_By": "IaC Deployment"
       }
+    },
+    "avdVnetId": {
+      "type": "string"
+    },
+    "devVnetId": {
+      "type": "string"
+    },
+    "prodVnetId": {
+      "type": "string"
     }
   },
   "variables": {
@@ -171,6 +180,60 @@
       "dependsOn": [
         "[resourceId('Microsoft.Network/publicIPAddresses', 'GWpubIP')]",
         "[resourceId('Microsoft.Network/virtualnetworks', variables('servicesVnet'))]"
+      ]
+    },
+    {
+      "type": "Microsoft.Network/virtualNetworks/virtualNetworkPeerings",
+      "apiVersion": "2020-05-01",
+      "name": "servicesToAvdPeering",
+      "location": "[variables('location')]",
+      "properties": {
+        "remoteVirtualNetwork": {
+          "id": "[parameters('avdVnetId')]"
+        },
+        "allowVirtualNetworkAccess": true,
+        "allowForwardedTraffic": true,
+        "allowGatewayTransit": false,
+        "useRemoteGateways": false
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Network/virtualNetworks', variables('servicesVnet'))]"
+      ]
+    },
+    {
+      "type": "Microsoft.Network/virtualNetworks/virtualNetworkPeerings",
+      "apiVersion": "2020-05-01",
+      "name": "servicesToDevPeering",
+      "location": "[variables('location')]",
+      "properties": {
+        "remoteVirtualNetwork": {
+          "id": "[parameters('devVnetId')]"
+        },
+        "allowVirtualNetworkAccess": true,
+        "allowForwardedTraffic": true,
+        "allowGatewayTransit": false,
+        "useRemoteGateways": false
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Network/virtualNetworks', variables('servicesVnet'))]"
+      ]
+    },
+    {
+      "type": "Microsoft.Network/virtualNetworks/virtualNetworkPeerings",
+      "apiVersion": "2020-05-01",
+      "name": "servicesToProdPeering",
+      "location": "[variables('location')]",
+      "properties": {
+        "remoteVirtualNetwork": {
+          "id": "[parameters('prodVnetId')]"
+        },
+        "allowVirtualNetworkAccess": true,
+        "allowForwardedTraffic": true,
+        "allowGatewayTransit": false,
+        "useRemoteGateways": false
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Network/virtualNetworks', variables('servicesVnet'))]"
       ]
     }
   ]


### PR DESCRIPTION
* **avddeploy.bicep**: Add `servicesVnetId` parameter and `avdToServicesPeering` resource with `remoteVirtualNetwork` property set to `servicesVnetId`.
* **avddeploy.json**: Add `servicesVnetId` parameter and `avdToServicesPeering` resource with `remoteVirtualNetwork` property set to `servicesVnetId`.
* **devdeploy.bicep**: Add `servicesVnetId` parameter and `devToServicesPeering` resource with `remoteVirtualNetwork` property set to `servicesVnetId`.
* **devdeploy.json**: Add `servicesVnetId` parameter and `devToServicesPeering` resource with `remoteVirtualNetwork` property set to `servicesVnetId`.
* **proddeploy.bicep**: Add `servicesVnetId` parameter and `prodToServicesPeering` resource with `remoteVirtualNetwork` property set to `servicesVnetId`.
* **proddeploy.json**: Add `servicesVnetId` parameter and `prodToServicesPeering` resource with `remoteVirtualNetwork` property set to `servicesVnetId`.
* **servicesdeploy.bicep**: Add `avdVnetId`, `devVnetId`, and `prodVnetId` parameters. Add `servicesToAvdPeering`, `servicesToDevPeering`, and `servicesToProdPeering` resources with `remoteVirtualNetwork` properties set to respective VNET IDs.
* **servicesdeploy.json**: Add `avdVnetId`, `devVnetId`, and `prodVnetId` parameters. Add `servicesToAvdPeering`, `servicesToDevPeering`, and `servicesToProdPeering` resources with `remoteVirtualNetwork` properties set to respective VNET IDs.